### PR TITLE
Add editor config and prettier config files. Also enable VS Code autoformat on save

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig helps maintain consistent coding styles for multiple developers
+# working on the same project across various editors and IDEs.
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Ignore artifacts:
+build
+coverage
+node_modules
+
+# Ignore all HTML files:
+*.html
+
+# Ignore all files in the scripts directory:
+scripts
+
+# Ignore all files in the temp directory:
+temp

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "build": "tsc",
-    "start": "ts-node src/main.ts"
+    "start": "ts-node src/main.ts",
+    "format": "prettier --write ."
   },
   "keywords": [],
   "author": "Michael Schilling",
@@ -16,7 +17,8 @@
   "devDependencies": {
     "@types/node": "^22.7.6",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "prettier": "^2.5.1"
   },
   "dependencies": {
     "@types/luxon": "^3.4.2",


### PR DESCRIPTION
Add editor config, Prettier config, and VS Code settings for autoformat on save.

* Add `.editorconfig` file with standard editor configuration settings.
* Add `.prettierrc` file with standard Prettier configuration settings.
* Add `.prettierignore` file with standard Prettier ignore settings.
* Modify `package.json` to add `prettier` dependency and `format` script.
* Add `.vscode/settings.json` file to enable autoformat on save.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mschilling/deskbird-scheduler?shareId=36a60816-dbe5-4217-9c1d-fa3772277993).