### PR TITLE
Enable Dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Fixes #5

Add Dependabot configuration file to enable weekly updates.

* Create a new file `dependabot.yml` in the `.github` directory
* Add configuration to run Dependabot on a weekly basis
* Include updates for both `npm` and `github-actions` dependencies
