### PR TITLE
Update cronjob for wintertime

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: Basic Workflow
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 22 * * *' # Runs at the end of every day (midnight Amsterdam converted to UTC)
+    - cron: '0 23 * * *' # Runs at the end of every day (midnight Amsterdam converted to UTC)
 
 jobs:
   simple-task:


### PR DESCRIPTION
Fixes #11 

---
This pull request includes a minor change to the `.github/workflows/workflow.yml` file. The change updates the cron schedule to run the workflow at a different time.

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L6-R6): Updated the cron schedule to run at 23:00 UTC instead of 22:00 UTC.