### PR TITLE
fix: back to summertime

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: Basic Workflow
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * *' # Runs at the end of every day (midnight Amsterdam converted to UTC)
+    - cron: '0 22 * * *' # Runs at the end of every day (midnight Amsterdam converted to UTC)
 
 jobs:
   simple-task:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/workflow.yml` file. The change adjusts the schedule for the workflow to run one hour earlier, updating the cron expression to reflect this.